### PR TITLE
Added envelope number support to ACS

### DIFF
--- a/Slingshot.ACS/Slingshot.ACS/Utilities/Translators/AcsPerson.cs
+++ b/Slingshot.ACS/Slingshot.ACS/Utilities/Translators/AcsPerson.cs
@@ -248,7 +248,19 @@ namespace Slingshot.ACS.Utilities.Translators
                     PersonId = person.Id
                 } );
             }
-            
+
+            // envelope number
+            var envelopeNumber = row.Field<int?>( "EnvelopeNumber" );
+            if ( envelopeNumber.HasValue )
+            {
+                person.Attributes.Add( new PersonAttributeValue
+                {
+                    AttributeKey = "core_GivingEnvelopeNumber",
+                    AttributeValue = envelopeNumber.Value.ToString(),
+                    PersonId = person.Id
+                } );
+            }
+
             // loop through any attributes found
             foreach ( var attrib in AcsApi.PersonAttributes )
             {


### PR DESCRIPTION
This will add support for pulling envelope numbers from ACS into the core envelope number attribute in Rock.