### PR TITLE
CCB Group updates and bug fixes

### DIFF
--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -105,6 +105,11 @@ namespace Slingshot.CCB.Utilities
         /// </value>
         public static bool IsConnected { get; private set; } = false;
 
+        /// <summary>
+        /// The identifier to use for unknown grouptypes
+        /// </summary>
+        public const int GROUPTYPE_UNKNOWN_ID = 10000;
+
         #region API Call Paths
 
         private const string API_STATUS = "api.php?srv=api_status";
@@ -173,12 +178,13 @@ namespace Slingshot.CCB.Utilities
                 foreach ( var sourceGroupType in sourceGroupTypes )
                 {
                     var groupType = new GroupType();
-
                     groupType.Id = sourceGroupType.Element( "id" ).Value.AsInteger();
                     groupType.Name = sourceGroupType.Element( "name" )?.Value;
-
                     groupTypes.Add( groupType );
                 }
+
+                // add an unknown type to cover missing groups
+                groupTypes.Add( new GroupType { Id = GROUPTYPE_UNKNOWN_ID, Name = "Unknown" } );
             }
             catch ( Exception ex )
             {
@@ -203,7 +209,7 @@ namespace Slingshot.CCB.Utilities
             WriteGroupAttributes();
 
             // write departments
-            ExportDeparments();
+            ExportDepartments();
 
             // get groups
             try
@@ -239,6 +245,11 @@ namespace Slingshot.CCB.Utilities
                             {
                                 // write out the group if its type was selected for export
                                 var groupTypeId = groupNode.Element( "group_type" ).Attribute( "id" ).Value.AsInteger();
+                                if ( groupTypeId == 0 )
+                                {
+                                    groupTypeId = GROUPTYPE_UNKNOWN_ID;
+                                }
+
                                 if ( selectedGroupTypes.Contains( groupTypeId ) )
                                 {
                                     var importGroups = CcbGroup.Translate( groupNode );
@@ -285,7 +296,7 @@ namespace Slingshot.CCB.Utilities
         /// <summary>
         /// Exports the deparments.
         /// </summary>
-        private static void ExportDeparments()
+        private static void ExportDepartments()
         {
             try
             {

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -318,6 +318,7 @@ namespace Slingshot.CCB.Utilities
                     group.Id = ( "9999" + sourceDepartment.Element( "id" ).Value ).AsInteger();
                     group.Name = sourceDepartment.Element( "name" )?.Value;
                     group.Order = sourceDepartment.Element( "order" ).Value.AsInteger();
+                    group.IsActive = true;
                     group.GroupTypeId = 9999;
 
                     ImportPackage.WriteToPackage( group );

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbGroup.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbGroup.cs
@@ -33,10 +33,12 @@ namespace Slingshot.CCB.Utilities.Translators
 
             ProcessBooleanAttribute( group, inputGroup.Element( "childcare_provided" ), "HasChildcare" );
 
-            if ( group.GroupTypeId != 0 )
+            if ( group.GroupTypeId == 0 )
             {
-                groups.Add( group );
+                group.GroupTypeId = CcbApi.GROUPTYPE_UNKNOWN_ID;
             }
+
+            groups.Add( group );
 
             // add the department as a group with an id of 9999 + its id to create a unique group id for it
             if ( inputGroup.Element( "department" ) != null && inputGroup.Element( "department" ).Attribute( "id" ) != null && inputGroup.Element( "department" ).Attribute( "id" ).Value.IsNotNullOrWhitespace() )

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
@@ -161,7 +161,7 @@ namespace Slingshot.CCB.Utilities.Translators
                         person.MaritalStatus = MaritalStatus.Unknown;
                         if ( maritalStatus.IsNotNullOrWhitespace() )
                         {
-                            notes.Add( "maritial_status:" + maritalStatus );
+                            notes.Add( "marital_status:" + maritalStatus );
                         }
                         break;
                 }

--- a/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
+++ b/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
@@ -134,6 +134,10 @@ namespace Slingshot.Core.Utilities
                         // group attributes
                         var groupAttributeValue = new GroupAttributeValue();
                         textWriters.Add( groupAttributeValue.GetType().Name, (TextWriter)File.CreateText( $@"{_packageDirectory}\{groupAttributeValue.GetFileName()}" ) );
+
+                        // group addresses
+                        var groupAddress = new GroupAddress();
+                        textWriters.Add( groupAddress.GetType().Name, (TextWriter)File.CreateText( $@"{_packageDirectory}\{groupAddress.GetFileName()}" ) );
                     }
                 }
 
@@ -199,6 +203,12 @@ namespace Slingshot.Core.Utilities
                         var newGroupAttributeValueCsvWriter = new CsvWriter( textWriters[groupAttributeValue.GetType().Name] );
                         csvWriters.Add( groupAttributeValue.GetType().Name, newGroupAttributeValueCsvWriter );
                         newGroupAttributeValueCsvWriter.WriteHeader<GroupAttributeValue>();
+
+                        // group addresses
+                        var groupAddress = new GroupAddress();
+                        var newGroupAddressCsvWriter = new CsvWriter( textWriters[groupAddress.GetType().Name] );
+                        csvWriters.Add( groupAddress.GetType().Name, newGroupAddressCsvWriter );
+                        newGroupAddressCsvWriter.WriteHeader<GroupAddress>();
                     }
                 }
 
@@ -217,7 +227,7 @@ namespace Slingshot.Core.Utilities
                     {
                         foreach ( var attribute in ( (Person)importModel ).Attributes )
                         {
-                            csvPersonAttributeValueWriter.WriteRecord<PersonAttributeValue>( attribute );
+                            csvPersonAttributeValueWriter.WriteRecord( attribute );
                         }
                     }
 
@@ -229,7 +239,7 @@ namespace Slingshot.Core.Utilities
                     {
                         foreach ( var phone in ( (Person)importModel ).PhoneNumbers )
                         {
-                            csvPersonPhoneWriter.WriteRecord<PersonPhone>( phone );
+                            csvPersonPhoneWriter.WriteRecord( phone );
                         }
                     }
 
@@ -241,7 +251,7 @@ namespace Slingshot.Core.Utilities
                     {
                         foreach ( var address in ( (Person)importModel ).Addresses )
                         {
-                            csvPersonAddressWriter.WriteRecord<PersonAddress>( address );
+                            csvPersonAddressWriter.WriteRecord( address );
                         }
                     }
                 }
@@ -260,11 +270,11 @@ namespace Slingshot.Core.Utilities
                     {
                         foreach ( var transaction in ( (FinancialBatch)importModel ).FinancialTransactions )
                         {
-                            csvFinancialTransactionWriter.WriteRecord<FinancialTransaction>( transaction );
+                            csvFinancialTransactionWriter.WriteRecord( transaction );
 
                             foreach ( var transactionDetail in transaction.FinancialTransactionDetails )
                             {
-                                csvFinancialTransactionDetailWriter.WriteRecord<FinancialTransactionDetail>( transactionDetail );
+                                csvFinancialTransactionDetailWriter.WriteRecord( transactionDetail );
                             }
                         }
                     }
@@ -281,7 +291,7 @@ namespace Slingshot.Core.Utilities
                     {
                         foreach ( var groupMemberItem in ( (Group)importModel ).GroupMembers )
                         {
-                            csvGroupMemberWriter.WriteRecord<GroupMember>( groupMemberItem );
+                            csvGroupMemberWriter.WriteRecord( groupMemberItem );
                         }
                     }
 
@@ -293,7 +303,19 @@ namespace Slingshot.Core.Utilities
                     {
                         foreach ( var attribute in ( (Group)importModel ).Attributes )
                         {
-                            csvPersonAttributeValueWriter.WriteRecord<GroupAttributeValue>( attribute );
+                            csvPersonAttributeValueWriter.WriteRecord( attribute );
+                        }
+                    }
+
+                    // group addresses
+                    var groupAddress = new GroupAddress();
+                    var csvGroupAddressWriter = csvWriters[groupAddress.GetType().Name];
+
+                    if ( csvGroupAddressWriter != null )
+                    {
+                        foreach ( var address in ( (Group)importModel ).Addresses )
+                        {
+                            csvGroupAddressWriter.WriteRecord( address );
                         }
                     }
                 }


### PR DESCRIPTION
This PR is in conjunction with a Rock PR to fix multiple items found during a CCB migration.

## General

- Fix spelling of Marital Status
- Fix spelling of Departments

## Groups

- Add an `Unknown` GroupType to import Groups the API doesn't export with a grouptype
- Add a new Group Address model and file export
- Mark department/top level groups as Active on export

