### PR TITLE
Added error message for Slingshot.ACS if required data (Email Addresses and Campus data) is not included in the ACS Export File.

### DIFF
--- a/Slingshot.ACS/Slingshot.ACS/MainWindow.xaml.cs
+++ b/Slingshot.ACS/Slingshot.ACS/MainWindow.xaml.cs
@@ -153,6 +153,11 @@ namespace Slingshot.ACS
                 cblEmailTypes.ItemsSource = EmailTypesComboBoxItems;
                 cblEmailTypes.SelectedIndex = 0;
             }
+            else
+            {
+                btnDownloadPackage.IsEnabled = false;
+                txtMessages.Text = "ERROR:  Cannot Export Data without Email Addresses." + Environment.NewLine;
+            }
 
             // populate campus fields combobox
             ExportCampus = AcsApi.LoadPersonFields();
@@ -168,6 +173,11 @@ namespace Slingshot.ACS
 
                 cblCampus.ItemsSource = ExportCampusComboBoxItems;
                 cblCampus.SelectedIndex = 0;
+            }
+            else
+            {
+                btnDownloadPackage.IsEnabled = false;
+                txtMessages.Text += "ERROR:  Cannot Export Data without Campus data." + Environment.NewLine;
             }
 
             txtImportCutOff.Text = DateTime.Now.ToShortDateString();


### PR DESCRIPTION
Prevents application from crashing with no notification to user due to null reference exception.