### PR TITLE
Ccb misc updates

### DIFF
--- a/Slingshot.CCB/Slingshot.CCB/Login.xaml
+++ b/Slingshot.CCB/Slingshot.CCB/Login.xaml
@@ -23,7 +23,7 @@
             <TextBox Name="txtHostname" Grid.Row="0" Grid.Column="1" Margin="0,2,0,10" Padding="3" Text="" />
 
             <Label Grid.Row="1">API Username</Label>
-            <TextBox Name="txtApiUsername" Grid.Row="1" Grid.Column="1" Margin="0,2,0,10" Padding="3" Text="RockExportTest" />
+            <TextBox Name="txtApiUsername" Grid.Row="1" Grid.Column="1" Margin="0,2,0,10" Padding="3" Text="" />
 
             <Label Grid.Row="2">API Password</Label>
             <TextBox Name="txtApiPassword" Grid.Row="2" Grid.Column="1" Margin="0,2,0,10" Padding="3" Text="" />

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml
@@ -75,8 +75,12 @@
                         <Label Content="Advanced" FontWeight="Bold" Margin="0,0,0,0"/>
                         <CheckBox Name="cbDumpResponseToXmlFile" Content="Dump Response to XmlFiles" Margin="0,10,0,10"  Padding="3,0,0,0"  />
                         <CheckBox Name="cbConsolidateSchedules" Content="Consolidate Schedules to Day of Week and Time" Margin="0,0,0,10"  Padding="3,0,0,0"  />
-                        <Label Name="lblLoopThreshold" Content="Max API Loops:" Margin="0,0,462,-25" Padding="3" Width="90px" />
-                        <TextBox x:Name="txtLoopThreshold" Margin="95,0,367,10" Padding="0,3" Width="85px" PreviewTextInput="TxtLoopThreshold_PreviewTextInput" />
+                        <Label Name="lblLoopThreshold" Content="Max API Loops:" Padding="0,0,0,3" VerticalAlignment="Bottom" MinWidth="100" />
+                        <TextBox x:Name="txtLoopThreshold" Margin="0,0,0,10" Padding="3" PreviewTextInput="TxtLoopThreshold_PreviewTextInput" MinWidth="100" />
+                        <TextBlock Name="lblLoopThresholdPost" Text="This is maximum number of API requests for People and Groups." Margin="10,-5,10,10" Padding="0" Foreground="Gray" />
+                        <Label Name="lblGroupsPerPage" Content="Groups Per Page:" Padding="0,0,0,3" VerticalAlignment="Bottom" MinWidth="100" />
+                        <TextBox x:Name="txtGroupsPerPage" Margin="0,0,0,10" Padding="3" PreviewTextInput="TxtLoopThreshold_PreviewTextInput" MinWidth="100" />
+                        <TextBlock Name="lblGroupsPerPagePost" Text="This is the page size of the Group API requests. Group Members are returned with each Group. Large organizations could have timeout issues with the Slingshot default of 500. The CCB default is 25." Margin="10,-5,10,10" Padding="0" TextWrapping="Wrap" Foreground="Gray" />
                     </StackPanel>
 
                     <Button Name="btnDownloadPackage" Grid.Row="7" Click="btnDownloadPackage_Click">

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml
@@ -74,6 +74,7 @@
                 <StackPanel Grid.Row="6">
                     <Label Content="Advanced" FontWeight="Bold" Margin="0,0,0,0"/>
                     <CheckBox Name="cbDumpResponseToXmlFile" Content="Dump Response to XmlFiles" Margin="0,10,0,10"  Padding="3,0,0,0"  />
+                    <CheckBox Name="cbConsolidateSchedules" Content="Consolidate Schedules to Day of Week and Time" Margin="0,0,0,10"  Padding="3,0,0,0"  />
                 </StackPanel>
 
                 <Button Name="btnDownloadPackage" Grid.Row="7" Click="btnDownloadPackage_Click">

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml
@@ -23,7 +23,7 @@
                         </Grid>
                     </ItemsPanelTemplate>
                 </StatusBar.ItemsPanel>
-            
+
                 <StatusBarItem>
                     <TextBlock Name="lblApiUsage" />
                 </StatusBarItem>
@@ -37,51 +37,53 @@
             </StatusBar>
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <Grid Margin="30" Name="gridMain">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
 
-                <Label Content="Import Records Modified Since" Grid.Row="1" FontWeight="Bold" />
-                <TextBox Name="txtImportCutOff" Grid.Row="2"  Margin="0,0,0,10" Padding="3" />
+                    <Label Content="Import Records Modified Since (Leave Blank To Return All Records)" Grid.Row="1" FontWeight="Bold" />
+                    <TextBox Name="txtImportCutOff" Grid.Row="2"  Margin="0,0,0,10" Padding="3" />
 
-                <Label Content="Export Data Types" Grid.Row="3" FontWeight="Bold" />
-                <CheckBox Name="cbIndividuals" Grid.Row="4" IsChecked="True" Content="Individuals" Margin="0,10,0,10" />
-                <CheckBox Name="cbContributions" Grid.Row="4" IsChecked="True" Content="Contributions" Margin="90,10,0,10" />
-                <CheckBox Name="cbGroups" Grid.Row="4" IsChecked="True" Content="Groups" Margin="195,10,0,10" Checked="cbGroups_Checked" Unchecked="cbGroups_Checked" />
-                <CheckBox Name="cbAttendance" Grid.Row="4" IsChecked="True" Content="Attendance" Margin="265,10,0,10" />
+                    <Label Content="Export Data Types" Grid.Row="3" FontWeight="Bold" />
+                    <CheckBox Name="cbIndividuals" Grid.Row="4" IsChecked="True" Content="Individuals" Margin="0,10,0,10" />
+                    <CheckBox Name="cbContributions" Grid.Row="4" IsChecked="True" Content="Contributions" Margin="90,10,0,10" />
+                    <CheckBox Name="cbGroups" Grid.Row="4" IsChecked="True" Content="Groups" Margin="195,10,0,10" Checked="cbGroups_Checked" Unchecked="cbGroups_Checked" />
+                    <CheckBox Name="cbAttendance" Grid.Row="4" IsChecked="True" Content="Attendance" Margin="265,10,0,10" />
 
-                <Label Content="Group Types To Export" Grid.Row="5" FontWeight="Bold" Margin="0,0,0,0"/>
-                <ListBox ItemsSource="{Binding ExportGroupTypes}" Grid.Row="5" HorizontalAlignment="Left" Margin="0,30,0,10" Name="cblGroupTypes" BorderThickness="0" Grid.Column="3">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate >
-                            <StackPanel Orientation="Horizontal" Width="Auto" Margin="0,0,0,0" >
-                                <CheckBox Content="{Binding Text}" IsChecked="{Binding Checked, Mode=TwoWay}" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
-                <StackPanel Grid.Row="6">
-                    <Label Content="Advanced" FontWeight="Bold" Margin="0,0,0,0"/>
-                    <CheckBox Name="cbDumpResponseToXmlFile" Content="Dump Response to XmlFiles" Margin="0,10,0,10"  Padding="3,0,0,0"  />
-                    <CheckBox Name="cbConsolidateSchedules" Content="Consolidate Schedules to Day of Week and Time" Margin="0,0,0,10"  Padding="3,0,0,0"  />
-                </StackPanel>
+                    <Label Content="Group Types To Export" Grid.Row="5" FontWeight="Bold" Margin="0,0,0,0"/>
+                    <ListBox ItemsSource="{Binding ExportGroupTypes}" Grid.Row="5" HorizontalAlignment="Left" Margin="0,30,0,10" Name="cblGroupTypes" BorderThickness="0" Grid.Column="3">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate >
+                                <StackPanel Orientation="Horizontal" Width="Auto" Margin="0,0,0,0" >
+                                    <CheckBox Content="{Binding Text}" IsChecked="{Binding Checked, Mode=TwoWay}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                    <StackPanel Grid.Row="6">
+                        <Label Content="Advanced" FontWeight="Bold" Margin="0,0,0,0"/>
+                        <CheckBox Name="cbDumpResponseToXmlFile" Content="Dump Response to XmlFiles" Margin="0,10,0,10"  Padding="3,0,0,0"  />
+                        <CheckBox Name="cbConsolidateSchedules" Content="Consolidate Schedules to Day of Week and Time" Margin="0,0,0,10"  Padding="3,0,0,0"  />
+                        <Label Name="lblLoopThreshold" Content="Max API Loops:" Margin="0,0,462,-25" Padding="3" Width="90px" />
+                        <TextBox x:Name="txtLoopThreshold" Margin="95,0,367,10" Padding="0,3" Width="85px" PreviewTextInput="TxtLoopThreshold_PreviewTextInput" />
+                    </StackPanel>
 
-                <Button Name="btnDownloadPackage" Grid.Row="7" Click="btnDownloadPackage_Click">
-                    <Label Content="Create Download Package" />
-                </Button>
-                <TextBlock Name="txtMessages" TextWrapping="WrapWithOverflow" Grid.Row="8" Margin="0,10,0,0" />
-            </Grid>
+                    <Button Name="btnDownloadPackage" Grid.Row="7" Click="btnDownloadPackage_Click">
+                        <Label Content="Create Download Package" />
+                    </Button>
+                    <TextBlock Name="txtMessages" TextWrapping="WrapWithOverflow" Grid.Row="8" Margin="0,10,0,0" />
+                </Grid>
             </ScrollViewer>
         </DockPanel>
     </Grid>

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
@@ -36,6 +36,7 @@ namespace Slingshot.CCB
             InitializeComponent();
 
             txtLoopThreshold.Text = "100";
+            txtGroupsPerPage.Text = "500";
 
             _apiUpdateTimer.Tick += _apiUpdateTimer_Tick;
             _apiUpdateTimer.Interval = new TimeSpan( 0, 2, 30 );
@@ -109,7 +110,7 @@ namespace Slingshot.CCB
             {
                 exportWorker.ReportProgress( 54, $"Exporting Groups..." );
 
-                CcbApi.ExportGroups( ExportGroupTypes.Select( t => t.Id ).ToList(), exportSettings.ModifiedSince );
+                CcbApi.ExportGroups( ExportGroupTypes.Select( t => t.Id ).ToList(), exportSettings.ModifiedSince, CcbApi.GroupsPerApiPage );
 
                 if ( CcbApi.ErrorMessage.IsNotNullOrWhitespace() )
                 {
@@ -194,6 +195,11 @@ namespace Slingshot.CCB
             if ( txtLoopThreshold.Text.IsNotNullOrWhitespace() && txtLoopThreshold.Text.AsInteger() > 0 )
             {
                 CcbApi.LoopThreshold = txtLoopThreshold.Text.AsInteger();
+            }
+
+            if ( txtGroupsPerPage.Text.IsNotNullOrWhitespace() && txtGroupsPerPage.Text.AsInteger() > 0 )
+            {
+                CcbApi.GroupsPerApiPage = txtLoopThreshold.Text.AsInteger();
             }
 
             // clear result from previous export

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace Slingshot.CCB
         {
             InitializeComponent();
 
-            _apiUpdateTimer.Tick += _apiUpdateTimer_Tick; ;
+            _apiUpdateTimer.Tick += _apiUpdateTimer_Tick;
             _apiUpdateTimer.Interval = new TimeSpan( 0, 2, 30 );
 
             exportWorker.DoWork += ExportWorker_DoWork;
@@ -62,12 +62,10 @@ namespace Slingshot.CCB
         {
             exportWorker.ReportProgress( 0, "" );
 
-            var exportSettings = (ExportSettings)e.Argument;
+            var exportSettings = ( ExportSettings ) e.Argument;
 
             // clear filesystem directories
             CcbApi.InitializeExport();
-
-            
 
             // export individuals
             if ( exportSettings.ExportIndividuals )
@@ -165,13 +163,14 @@ namespace Slingshot.CCB
             // add group types
             ExportGroupTypes = CcbApi.GetGroupTypes();
 
-            foreach ( var groupType in ExportGroupTypes ) {
+            foreach ( var groupType in ExportGroupTypes )
+            {
                 //cblGroupTypes.Items.Add( groupType );
                 GroupTypesCheckboxItems.Add( new CheckListItem { Id = groupType.Id, Text = groupType.Name, Checked = true } );
             }
 
             cblGroupTypes.ItemsSource = GroupTypesCheckboxItems;
-            
+
             txtImportCutOff.Text = DateTime.Now.ToShortDateString(); // remove before flight (sets today's date as the modified since)
         }
 
@@ -196,19 +195,19 @@ namespace Slingshot.CCB
             // launch our background export
             var exportSettings = new ExportSettings
             {
-                ModifiedSince = (DateTime)txtImportCutOff.Text.AsDateTime(),
+                ModifiedSince = ( DateTime ) txtImportCutOff.Text.AsDateTime(),
                 ExportContributions = cbContributions.IsChecked.Value,
                 ExportIndividuals = cbIndividuals.IsChecked.Value,
                 ExportAttendance = cbAttendance.IsChecked.Value
             };
 
             // configure group types to export
-            foreach ( var selectedItem in GroupTypesCheckboxItems.Where( i => i.Checked ))
+            foreach ( var selectedItem in GroupTypesCheckboxItems.Where( i => i.Checked ) )
             {
                 exportSettings.ExportGroupTypes.Add( selectedItem.Id );
             }
 
-            exportWorker.RunWorkerAsync( exportSettings ); 
+            exportWorker.RunWorkerAsync( exportSettings );
         }
 
         #region Window Events
@@ -219,7 +218,6 @@ namespace Slingshot.CCB
             if ( cbGroups.IsChecked.Value )
             {
                 gridMain.RowDefinitions[5].Height = new GridLength( 1, GridUnitType.Auto );
-                
             }
             else
             {

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
@@ -184,6 +184,9 @@ namespace Slingshot.CCB
             // Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package
             CcbApi.DumpResponseToXmlFile = cbDumpResponseToXmlFile.IsChecked ?? false;
 
+            // Set ConsolidateScheduleNames to true to consolidate schedules names as 'Sunday at 11:00 AM'
+            CcbApi.ConsolidateScheduleNames = cbConsolidateSchedules.IsChecked ?? false;
+
             // clear result from previous export
             txtExportMessage.Text = string.Empty;
 

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
@@ -35,6 +35,8 @@ namespace Slingshot.CCB
         {
             InitializeComponent();
 
+            txtLoopThreshold.Text = "100";
+
             _apiUpdateTimer.Tick += _apiUpdateTimer_Tick;
             _apiUpdateTimer.Interval = new TimeSpan( 0, 2, 30 );
 
@@ -189,13 +191,18 @@ namespace Slingshot.CCB
             // Set ConsolidateScheduleNames to true to consolidate schedules names as 'Sunday at 11:00 AM'
             CcbApi.ConsolidateScheduleNames = cbConsolidateSchedules.IsChecked ?? false;
 
+            if ( txtLoopThreshold.Text.IsNotNullOrWhitespace() && txtLoopThreshold.Text.AsInteger() > 0 )
+            {
+                CcbApi.LoopThreshold = txtLoopThreshold.Text.AsInteger();
+            }
+
             // clear result from previous export
             txtExportMessage.Text = string.Empty;
 
             // launch our background export
             var exportSettings = new ExportSettings
             {
-                ModifiedSince = ( DateTime ) txtImportCutOff.Text.AsDateTime(),
+                ModifiedSince = txtImportCutOff.Text.AsDateTime(),
                 ExportContributions = cbContributions.IsChecked.Value,
                 ExportIndividuals = cbIndividuals.IsChecked.Value,
                 ExportAttendance = cbAttendance.IsChecked.Value
@@ -225,11 +232,22 @@ namespace Slingshot.CCB
             }
         }
         #endregion
+
+        private void TxtLoopThreshold_PreviewTextInput( object sender, TextCompositionEventArgs e )
+        {
+            e.Handled = !IsValid( ( ( TextBox ) sender ).Text + e.Text );
+        }
+
+        public static bool IsValid( string str )
+        {
+            int i;
+            return int.TryParse( str, out i ) && i >= 1 && i <= 9999;
+        }
     }
 
     public class ExportSettings
     {
-        public DateTime ModifiedSince { get; set; } = DateTime.Now;
+        public DateTime? ModifiedSince { get; set; }
 
         public bool ExportIndividuals { get; set; } = true;
 

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
@@ -53,6 +53,7 @@ namespace Slingshot.CCB
 
         private void ExportWorker_RunWorkerCompleted( object sender, RunWorkerCompletedEventArgs e )
         {
+            btnDownloadPackage.IsEnabled = true;
             txtExportMessage.Text = "Export Complete";
             pbProgress.Value = 100;
         }
@@ -181,6 +182,8 @@ namespace Slingshot.CCB
         /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
         private void btnDownloadPackage_Click( object sender, RoutedEventArgs e )
         {
+            btnDownloadPackage.IsEnabled = false;
+
             // Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package
             CcbApi.DumpResponseToXmlFile = cbDumpResponseToXmlFile.IsChecked ?? false;
 

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
@@ -199,7 +199,7 @@ namespace Slingshot.CCB
 
             if ( txtGroupsPerPage.Text.IsNotNullOrWhitespace() && txtGroupsPerPage.Text.AsInteger() > 0 )
             {
-                CcbApi.GroupsPerApiPage = txtLoopThreshold.Text.AsInteger();
+                CcbApi.GroupsPerApiPage = txtGroupsPerPage.Text.AsInteger();
             }
 
             // clear result from previous export

--- a/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
+++ b/Slingshot.CCB/Slingshot.CCB/MainWindow.xaml.cs
@@ -37,9 +37,6 @@ namespace Slingshot.CCB
 
             _apiUpdateTimer.Tick += _apiUpdateTimer_Tick; ;
             _apiUpdateTimer.Interval = new TimeSpan( 0, 2, 30 );
-            
-            // Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package
-            CcbApi.DumpResponseToXmlFile = cbDumpResponseToXmlFile.IsChecked ?? false;
 
             exportWorker.DoWork += ExportWorker_DoWork;
             exportWorker.RunWorkerCompleted += ExportWorker_RunWorkerCompleted;
@@ -184,6 +181,9 @@ namespace Slingshot.CCB
         /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
         private void btnDownloadPackage_Click( object sender, RoutedEventArgs e )
         {
+            // Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package
+            CcbApi.DumpResponseToXmlFile = cbDumpResponseToXmlFile.IsChecked ?? false;
+
             // clear result from previous export
             txtExportMessage.Text = string.Empty;
 

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -41,18 +41,18 @@ namespace Slingshot.CCB.Utilities
             var response = base.Execute( restRequest );
             var remainingCalls = response.Headers
                 .Where( h => h.Name.Equals( "X-RATELIMIT-REMAINING", StringComparison.InvariantCultureIgnoreCase ) )
-                .Select( x => ((string)x.Value).AsIntegerOrNull() )
+                .Select( x => ( ( string ) x.Value ).AsIntegerOrNull() )
                 .FirstOrDefault();
             var resetTime = response.Headers
                 .Where( h => h.Name.Equals( "X-RATELIMIT-RESET", StringComparison.InvariantCultureIgnoreCase ) )
-                .Select( x => ((string)x.Value).AsDoubleOrNull() )
+                .Select( x => ( ( string ) x.Value ).AsDoubleOrNull() )
                 .FirstOrDefault();
 
             // allow the server to burst up to the throttle rate
             if ( remainingCalls.HasValue && remainingCalls < ThrottleRate && resetTime.HasValue )
             {
                 var coolDownTime = EpochTime.AddSeconds( resetTime.Value ) - DateTime.Now.ToUniversalTime();
-                if ( coolDownTime.Seconds > 0)
+                if ( coolDownTime.Seconds > 0 )
                 {
                     CcbApi.ErrorMessage = $"Throttling API requests for {coolDownTime.Seconds} seconds";
                     Thread.Sleep( coolDownTime );
@@ -593,7 +593,7 @@ namespace Slingshot.CCB.Utilities
                 {
                     var financialAccount = new FinancialAccount();
                     financialAccount.Name = sourceAccount.Element( "name" )?.Value;
-                    financialAccount.Id = (int)sourceAccount.Attribute( "id" )?.Value.AsInteger();
+                    financialAccount.Id = ( int ) sourceAccount.Attribute( "id" )?.Value.AsInteger();
 
                     var parentAccountId = sourceAccount.Element( "parent" )?.Attribute( "id" )?.Value;
                     if ( parentAccountId.IsNotNullOrWhitespace() )

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -193,6 +193,7 @@ namespace Slingshot.CCB.Utilities
         private const string API_CUSTOM_FIELDS = "/api.php?srv=custom_field_labels";
         private const string API_FINANCIAL_ACCOUNTS = "/api.php?srv=transaction_detail_type_list";
         private const string API_FINANCIAL_BATCHES = "/api.php?srv=batch_profiles_in_date_range&date_start={startDate}&date_end={endDate}";
+        private const string API_FINANCIAL_BATCHES_ALL = "/api.php?srv=batch_profiles";
         private const string API_GROUP_TYPES = "/api.php?srv=group_type_list";
         private const string API_GROUPS = "/api.php?srv=group_profiles&modified_since={modifiedSince}&include_participants=true&page={currentPage}&per_page={perPage}";
         private const string API_GROUPS_ALL = "/api.php?srv=group_profiles&include_participants=true&page={currentPage}&per_page={perPage}";
@@ -526,39 +527,92 @@ namespace Slingshot.CCB.Utilities
         /// <param name="modifiedSince">The modified since.</param>
         public static void ExportContributions( DateTime? modifiedSince )
         {
-            if ( !modifiedSince.HasValue )
+            if ( modifiedSince.HasValue )
             {
-                // only test since 2000 so not as many api hits as DateTime.MinValue
-                modifiedSince = "1/1/2000".AsDateTime();
-            }
 
-            // we'll make an api call for each month until the modifiedSince date
-            var today = DateTime.Now;
-            var numberOfMonths = ( ( ( today.Year - modifiedSince.Value.Year ) * 12 ) + today.Month - modifiedSince.Value.Month ) + 1;
-            int loopCounter = 0;
-            try
-            {
-                for ( int i = 0; i < numberOfMonths; i++ )
+                // we'll make an api call for each month until the modifiedSince date
+                var today = DateTime.Now;
+                var numberOfMonths = ( ( ( today.Year - modifiedSince.Value.Year ) * 12 ) + today.Month - modifiedSince.Value.Month ) + 1;
+                int loopCounter = 0;
+                try
                 {
-                    DateTime referenceDate = today.AddMonths( ( ( numberOfMonths - i ) - 1 ) * -1 );
-                    DateTime startDate = new DateTime( referenceDate.Year, referenceDate.Month, 1 );
-                    DateTime endDate = new DateTime( referenceDate.Year, referenceDate.Month, DateTime.DaysInMonth( referenceDate.Year, referenceDate.Month ) );
-
-                    // if it's the first instance set start date to the modifiedSince date
-                    if ( i == 0 )
+                    for ( int i = 0; i < numberOfMonths; i++ )
                     {
-                        startDate = modifiedSince.Value;
-                    }
+                        DateTime referenceDate = today.AddMonths( ( ( numberOfMonths - i ) - 1 ) * -1 );
+                        DateTime startDate = new DateTime( referenceDate.Year, referenceDate.Month, 1 );
+                        DateTime endDate = new DateTime( referenceDate.Year, referenceDate.Month, DateTime.DaysInMonth( referenceDate.Year, referenceDate.Month ) );
 
-                    // if it's the last time through set the end dat to today's date
-                    if ( i == numberOfMonths - 1 )
-                    {
-                        endDate = today;
-                    }
+                        // if it's the first instance set start date to the modifiedSince date
+                        if ( i == 0 )
+                        {
+                            startDate = modifiedSince.Value;
+                        }
 
-                    var request = new RestRequest( API_FINANCIAL_BATCHES, Method.GET );
-                    request.AddUrlSegment( "startDate", startDate.ToString( "yyyy-MM-dd" ) );
-                    request.AddUrlSegment( "endDate", endDate.ToString( "yyyy-MM-dd" ) );
+                        // if it's the last time through set the end dat to today's date
+                        if ( i == numberOfMonths - 1 )
+                        {
+                            endDate = today;
+                        }
+
+                        var request = new RestRequest( API_FINANCIAL_BATCHES, Method.GET );
+                        request.AddUrlSegment( "startDate", startDate.ToString( "yyyy-MM-dd" ) );
+                        request.AddUrlSegment( "endDate", endDate.ToString( "yyyy-MM-dd" ) );
+
+                        var response = _client.Execute( request );
+
+                        XDocument xdoc = XDocument.Parse( response.Content );
+
+                        if ( CcbApi.DumpResponseToXmlFile )
+                        {
+                            xdoc.Save( Path.Combine( ImportPackage.PackageDirectory, $"API_FINANCIAL_BATCHES_ResponseLog_{loopCounter++}.xml" ) );
+                        }
+
+                        var sourceBatches = xdoc.Element( "ccb_api" )?.Element( "response" )?.Element( "batches" ).Elements( "batch" );
+
+                        foreach ( var sourceBatch in sourceBatches )
+                        {
+                            var importBatch = CcbFinancialBatch.Translate( sourceBatch );
+
+                            var sourceTransactions = sourceBatch.Element( "transactions" ).Elements( "transaction" );
+
+                            foreach ( var sourceTransaction in sourceTransactions )
+                            {
+                                var importTransaction = CcbFinancialTransaction.Translate( sourceTransaction, sourceBatch.Attribute( "id" ).Value.AsInteger() );
+
+                                if ( importTransaction != null )
+                                {
+                                    importBatch.FinancialTransactions.Add( importTransaction );
+
+                                    var sourceTransactionDetails = sourceTransaction.Element( "transaction_details" ).Elements( "transaction_detail" );
+                                    foreach ( var sourceTransactionDetail in sourceTransactionDetails )
+                                    {
+                                        var importTransactionDetail = CcbFinancialTransactionDetail.Translate( sourceTransactionDetail, importTransaction.Id );
+
+                                        if ( importTransactionDetail != null )
+                                        {
+                                            importTransaction.FinancialTransactionDetails.Add( importTransactionDetail );
+                                        }
+                                    }
+                                }
+                            }
+
+                            if ( importBatch != null )
+                            {
+                                ImportPackage.WriteToPackage( importBatch );
+                            }
+                        }
+                    }
+                }
+                catch ( Exception ex )
+                {
+                    ErrorMessage = ex.Message;
+                }
+            }
+            else
+            {
+                try
+                {
+                    var request = new RestRequest( API_FINANCIAL_BATCHES_ALL, Method.GET );
 
                     var response = _client.Execute( request );
 
@@ -566,7 +620,7 @@ namespace Slingshot.CCB.Utilities
 
                     if ( CcbApi.DumpResponseToXmlFile )
                     {
-                        xdoc.Save( Path.Combine( ImportPackage.PackageDirectory, $"API_FINANCIAL_BATCHES_ResponseLog_{loopCounter++}.xml" ) );
+                        xdoc.Save( Path.Combine( ImportPackage.PackageDirectory, $"API_FINANCIAL_BATCHES_ALL_ResponseLog.xml" ) );
                     }
 
                     var sourceBatches = xdoc.Element( "ccb_api" )?.Element( "response" )?.Element( "batches" ).Elements( "batch" );
@@ -603,11 +657,12 @@ namespace Slingshot.CCB.Utilities
                             ImportPackage.WriteToPackage( importBatch );
                         }
                     }
+
                 }
-            }
-            catch ( Exception ex )
-            {
-                ErrorMessage = ex.Message;
+                catch ( Exception ex )
+                {
+                    ErrorMessage = ex.Message;
+                }
             }
         }
 

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -72,11 +72,23 @@ namespace Slingshot.CCB.Utilities
         private static RateLimitedRestClient _client;
         private static int loopThreshold = 100;
 
-        // Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package
-        public static bool DumpResponseToXmlFile { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether [dump response to XML file].
+        /// Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [dump response to XML file]; otherwise, <c>false</c>.
+        /// </value>
+        public static bool DumpResponseToXmlFile { get; set; } = false;
 
-        // Set ConsolidateScheduleNames to true to consolidate schedules names as 'Sunday at 11:00 AM'
-        public static bool ConsolidateScheduleNames { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether [consolidate schedule names].
+        /// Set ConsolidateScheduleNames to true to consolidate schedules names as 'Sunday at 11:00 AM'
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [consolidate schedule names]; otherwise, <c>false</c>.
+        /// </value>
+        public static bool ConsolidateScheduleNames { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the last run date.

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -714,6 +714,10 @@ namespace Slingshot.CCB.Utilities
             }
         }
 
+        /// <summary>
+        /// Writes the significant events.
+        /// </summary>
+        /// <param name="modifiedSince">The modified since.</param>
         private static void WriteSignificantEvents( DateTime modifiedSince )
         {
             var request = new RestRequest( API_INDIVIDUAL_SIGNIFICANT_EVENTS, Method.GET );

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -1032,7 +1032,7 @@ namespace Slingshot.CCB.Utilities
                             if ( eventItem.Element( "location" ) != null && eventItem.Element( "location" ).HasElements )
                             {
                                 eventDetail.LocationName = eventItem.Element( "location" ).Element( "name" ).Value;
-                                eventDetail.LocationStreetAddress = eventItem.Element( "location" ).Element( "street_address" ).Value;
+                                eventDetail.LocationStreetAddress = eventItem.Element( "location" ).Element( "street_address" ).Value.RemoveCrLf();
                                 eventDetail.LocationCity = eventItem.Element( "location" ).Element( "city" ).Value;
                                 eventDetail.LocationState = eventItem.Element( "location" ).Element( "state" ).Value;
                                 eventDetail.LocationZip = eventItem.Element( "location" ).Element( "zip" ).Value;

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -671,7 +671,7 @@ namespace Slingshot.CCB.Utilities
                     personAttribute.Key = field.Element( "name" ).Value.Replace( "_ind_", "_" ); // need to strip out the '_ind' so they match what is returned from CCB on the person record
                     personAttribute.Name = field.Element( "label" ).Value;
 
-                    if ( field.Element( "name" ).Value.Contains( "_text_" ) )
+                    if ( field.Element( "name" ).Value.Contains( "_text_" ) || field.Element( "name" ).Value.Contains( "_ind_pulldown_" ) )
                     {
                         personAttribute.FieldType = "Rock.Field.Types.TextFieldType";
                     }

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -77,6 +77,14 @@ namespace Slingshot.CCB.Utilities
         public static int LoopThreshold { get; set; } = 100;
 
         /// <summary>
+        /// Gets or sets the groups per API page.
+        /// </summary>
+        /// <value>
+        /// The groups per API page.
+        /// </value>
+        public static int GroupsPerApiPage { get; set; } = 500;
+
+        /// <summary>
         /// Gets or sets a value indicating whether [dump response to XML file].
         /// Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package.
         /// </summary>

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -70,11 +70,15 @@ namespace Slingshot.CCB.Utilities
     public static class CcbApi
     {
         private static RateLimitedRestClient _client;
-        private static int loopThreshold = 100;
+
+        /// <summary>
+        /// A developer safety blanket to prevent eating all the api calls for the day.
+        /// </summary>
+        public static int LoopThreshold { get; set; } = 100;
 
         /// <summary>
         /// Gets or sets a value indicating whether [dump response to XML file].
-        /// Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package
+        /// Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package.
         /// </summary>
         /// <value>
         ///   <c>true</c> if [dump response to XML file]; otherwise, <c>false</c>.
@@ -83,7 +87,7 @@ namespace Slingshot.CCB.Utilities
 
         /// <summary>
         /// Gets or sets a value indicating whether [consolidate schedule names].
-        /// Set ConsolidateScheduleNames to true to consolidate schedules names as 'Sunday at 11:00 AM'
+        /// Set ConsolidateScheduleNames to true to consolidate schedules names as 'Sunday at 11:00 AM'.
         /// </summary>
         /// <value>
         ///   <c>true</c> if [consolidate schedule names]; otherwise, <c>false</c>.
@@ -177,13 +181,16 @@ namespace Slingshot.CCB.Utilities
 
         private const string API_STATUS = "/api.php?srv=api_status";
         private const string API_INDIVIDUALS = "/api.php?srv=individual_profiles&modified_since={modifiedSince}&include_inactive=true&page={currentPage}&per_page={peoplePerPage}";
+        private const string API_INDIVIDUALS_ALL = "/api.php?srv=individual_profiles&include_inactive=true&page={currentPage}&per_page={peoplePerPage}";
         private const string API_CUSTOM_FIELDS = "/api.php?srv=custom_field_labels";
         private const string API_FINANCIAL_ACCOUNTS = "/api.php?srv=transaction_detail_type_list";
         private const string API_FINANCIAL_BATCHES = "/api.php?srv=batch_profiles_in_date_range&date_start={startDate}&date_end={endDate}";
         private const string API_GROUP_TYPES = "/api.php?srv=group_type_list";
         private const string API_GROUPS = "/api.php?srv=group_profiles&modified_since={modifiedSince}&include_participants=true&page={currentPage}&per_page={perPage}";
+        private const string API_GROUPS_ALL = "/api.php?srv=group_profiles&include_participants=true&page={currentPage}&per_page={perPage}";
         private const string API_DEPARTMENTS = "/api.php?srv=group_grouping_list";
         private const string API_EVENTS = "/api.php?srv=event_profiles&modified_since={modifiedSince}&page={currentPage}&per_page={itemsPerPage}";
+        private const string API_EVENTS_ALL = "/api.php?srv=event_profiles&page={currentPage}&per_page={itemsPerPage}";
         private const string API_ATTENDANCE = "/api.php?srv=attendance_profiles&start_date={startDate}&end_date={endDate}";
         private const string API_SIGNIFICANT_EVENT_LIST = "/api.php?srv=significant_event_list";
         private const string API_INDIVIDUAL_SIGNIFICANT_EVENTS = "/api.php?srv=individual_significant_events";
@@ -265,7 +272,7 @@ namespace Slingshot.CCB.Utilities
         /// <param name="selectedGroupTypes">The selected group types.</param>
         /// <param name="modifiedSince">The modified since.</param>
         /// <param name="perPage">The people per page.</param>
-        public static void ExportGroups( List<int> selectedGroupTypes, DateTime modifiedSince, int perPage = 500 )
+        public static void ExportGroups( List<int> selectedGroupTypes, DateTime? modifiedSince, int perPage = 500 )
         {
             // write out the group types
             WriteGroupTypes( selectedGroupTypes );
@@ -284,10 +291,20 @@ namespace Slingshot.CCB.Utilities
                 bool moreExist = true;
                 while ( moreExist )
                 {
-                    var request = new RestRequest( API_GROUPS, Method.GET );
-                    request.AddUrlSegment( "modifiedSince", modifiedSince.ToString( "yyyy-MM-dd" ) );
-                    request.AddUrlSegment( "currentPage", currentPage.ToString() );
-                    request.AddUrlSegment( "perPage", perPage.ToString() );
+                    RestRequest request;
+                    if ( modifiedSince.HasValue )
+                    { 
+                        request = new RestRequest( API_GROUPS, Method.GET );
+                        request.AddUrlSegment( "modifiedSince", modifiedSince.Value.ToString( "yyyy-MM-dd" ) );
+                        request.AddUrlSegment( "currentPage", currentPage.ToString() );
+                        request.AddUrlSegment( "perPage", perPage.ToString() );
+                    }
+                    else
+                    {
+                        request = new RestRequest( API_GROUPS_ALL, Method.GET );
+                        request.AddUrlSegment( "currentPage", currentPage.ToString() );
+                        request.AddUrlSegment( "perPage", perPage.ToString() );
+                    }
 
                     var response = _client.Execute( request );
 
@@ -345,7 +362,7 @@ namespace Slingshot.CCB.Utilities
                     }
 
                     // developer safety blanket (prevents eating all the api calls for the day)
-                    if ( loopCounter > loopThreshold )
+                    if ( loopCounter > LoopThreshold )
                     {
                         break;
                     }
@@ -400,7 +417,7 @@ namespace Slingshot.CCB.Utilities
         /// </summary>
         /// <param name="modifiedSince">The modified since.</param>
         /// <param name="peoplePerPage">The people per page.</param>
-        public static void ExportIndividuals( DateTime modifiedSince, int peoplePerPage = 500 )
+        public static void ExportIndividuals( DateTime? modifiedSince, int peoplePerPage = 500 )
         {
             // write out the person attributes
             WritePersonAttributes();
@@ -422,10 +439,20 @@ namespace Slingshot.CCB.Utilities
             {
                 while ( moreIndividualsExist )
                 {
-                    var request = new RestRequest( API_INDIVIDUALS, Method.GET );
-                    request.AddUrlSegment( "modifiedSince", modifiedSince.ToString( "yyyy-MM-dd" ) );
-                    request.AddUrlSegment( "currentPage", currentPage.ToString() );
-                    request.AddUrlSegment( "peoplePerPage", peoplePerPage.ToString() );
+                    RestRequest request;
+                    if ( modifiedSince.HasValue )
+                    {
+                        request = new RestRequest( API_INDIVIDUALS, Method.GET );
+                        request.AddUrlSegment( "modifiedSince", modifiedSince.Value.ToString( "yyyy-MM-dd" ) );
+                        request.AddUrlSegment( "currentPage", currentPage.ToString() );
+                        request.AddUrlSegment( "peoplePerPage", peoplePerPage.ToString() );
+                    }
+                    else
+                    {
+                        request = new RestRequest( API_INDIVIDUALS_ALL, Method.GET );
+                        request.AddUrlSegment( "currentPage", currentPage.ToString() );
+                        request.AddUrlSegment( "peoplePerPage", peoplePerPage.ToString() );
+                    }
 
                     var response = _client.Execute( request );
 
@@ -470,7 +497,7 @@ namespace Slingshot.CCB.Utilities
                     }
 
                     // developer safety blanket (prevents eating all the api calls for the day)
-                    if ( loopCounter > loopThreshold )
+                    if ( loopCounter > LoopThreshold )
                     {
                         break;
                     }
@@ -489,11 +516,17 @@ namespace Slingshot.CCB.Utilities
         /// Exports the contributions.
         /// </summary>
         /// <param name="modifiedSince">The modified since.</param>
-        public static void ExportContributions( DateTime modifiedSince )
+        public static void ExportContributions( DateTime? modifiedSince )
         {
+            if ( !modifiedSince.HasValue )
+            {
+                // only test since 2000 so not as many api hits as DateTime.MinValue
+                modifiedSince = "1/1/2000".AsDateTime();
+            }
+
             // we'll make an api call for each month until the modifiedSince date
             var today = DateTime.Now;
-            var numberOfMonths = ( ( ( today.Year - modifiedSince.Year ) * 12 ) + today.Month - modifiedSince.Month ) + 1;
+            var numberOfMonths = ( ( ( today.Year - modifiedSince.Value.Year ) * 12 ) + today.Month - modifiedSince.Value.Month ) + 1;
             int loopCounter = 0;
             try
             {
@@ -506,7 +539,7 @@ namespace Slingshot.CCB.Utilities
                     // if it's the first instance set start date to the modifiedSince date
                     if ( i == 0 )
                     {
-                        startDate = modifiedSince;
+                        startDate = modifiedSince.Value;
                     }
 
                     // if it's the last time through set the end dat to today's date
@@ -733,8 +766,14 @@ namespace Slingshot.CCB.Utilities
         /// Writes the significant events.
         /// </summary>
         /// <param name="modifiedSince">The modified since.</param>
-        private static void WriteSignificantEvents( DateTime modifiedSince )
+        private static void WriteSignificantEvents( DateTime? modifiedSince )
         {
+            if ( !modifiedSince.HasValue )
+            {
+                // DateTime.MinValue is fine because no api hits in this loop
+                modifiedSince = DateTime.MinValue;
+            }
+
             var request = new RestRequest( API_INDIVIDUAL_SIGNIFICANT_EVENTS, Method.GET );
             var response = _client.Execute( request );
 
@@ -762,7 +801,7 @@ namespace Slingshot.CCB.Utilities
                             var dateModified = significantEvent.Element( "modified" ).Value.AsDateTime();
                             if ( dateModified.HasValue )
                             {
-                                var result = DateTime.Compare( modifiedSince, dateModified.Value );
+                                var result = DateTime.Compare( modifiedSince.Value, dateModified.Value );
                                 if ( result <= 0 )
                                 {
                                     ImportPackage.WriteToPackage( new PersonAttributeValue
@@ -850,7 +889,7 @@ namespace Slingshot.CCB.Utilities
         /// <summary>
         /// Exports the attendance.
         /// </summary>
-        public static void ExportAttendance( DateTime modifiedSince )
+        public static void ExportAttendance( DateTime? modifiedSince )
         {
             // first we need to get the 'events' so we can get the group, location and schedule information
             // since the events have a different modification date than attendance we need to load all of the
@@ -923,11 +962,17 @@ namespace Slingshot.CCB.Utilities
             GetAttendance( modifiedSince, eventDetails );
         }
 
-        private static void GetAttendance( DateTime modifiedSince, List<EventDetail> eventDetails )
+        private static void GetAttendance( DateTime? modifiedSince, List<EventDetail> eventDetails )
         {
+            if ( !modifiedSince.HasValue )
+            {
+                // only test since 2000 so not as many api hits as DateTime.MinValue
+                modifiedSince = "1/1/2000".AsDateTime();
+            }
+
             // we'll make an api call for each month until the modifiedSince date
             var today = DateTime.Now;
-            var numberOfMonths = ( ( ( today.Year - modifiedSince.Year ) * 12 ) + today.Month - modifiedSince.Month ) + 1;
+            var numberOfMonths = ( ( ( today.Year - modifiedSince.Value.Year ) * 12 ) + today.Month - modifiedSince.Value.Month ) + 1;
             int loopCounter = 0;
 
             try
@@ -941,7 +986,7 @@ namespace Slingshot.CCB.Utilities
                     // if it's the first instance set start date to the modifiedSince date
                     if ( i == 0 )
                     {
-                        startDate = modifiedSince;
+                        startDate = modifiedSince.Value;
                     }
 
                     // if it's the last time through set the end dat to today's date
@@ -994,7 +1039,7 @@ namespace Slingshot.CCB.Utilities
         /// <param name="modifiedSince">The modified since.</param>
         /// <param name="itemsPerPage">The items per page.</param>
         /// <returns></returns>
-        private static List<EventDetail> GetAttendanceEvents( DateTime modifiedSince, int itemsPerPage )
+        private static List<EventDetail> GetAttendanceEvents( DateTime? modifiedSince, int itemsPerPage )
         {
             List<EventDetail> eventDetails = new List<EventDetail>();
 
@@ -1006,10 +1051,20 @@ namespace Slingshot.CCB.Utilities
             {
                 while ( moreItemsExist )
                 {
-                    var request = new RestRequest( API_EVENTS, Method.GET );
-                    request.AddUrlSegment( "modifiedSince", modifiedSince.ToString( "yyyy-MM-dd" ) );
-                    request.AddUrlSegment( "currentPage", currentPage.ToString() );
-                    request.AddUrlSegment( "itemsPerPage", itemsPerPage.ToString() );
+                    RestRequest request;
+                    if ( modifiedSince.HasValue )
+                    {
+                        request = new RestRequest( API_EVENTS, Method.GET );
+                        request.AddUrlSegment( "modifiedSince", modifiedSince.Value.ToString( "yyyy-MM-dd" ) );
+                        request.AddUrlSegment( "currentPage", currentPage.ToString() );
+                        request.AddUrlSegment( "itemsPerPage", itemsPerPage.ToString() );
+                    }
+                    else
+                    {
+                        request = new RestRequest( API_EVENTS_ALL, Method.GET );
+                        request.AddUrlSegment( "currentPage", currentPage.ToString() );
+                        request.AddUrlSegment( "itemsPerPage", itemsPerPage.ToString() );
+                    }
 
                     var response = _client.Execute( request );
 
@@ -1062,7 +1117,7 @@ namespace Slingshot.CCB.Utilities
                     }
 
                     // developer safety blanket (prevents eating all the api calls for the day)
-                    if ( loopCounter > loopThreshold )
+                    if ( loopCounter > LoopThreshold )
                     {
                         break;
                     }

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/CcbApi.cs
@@ -75,6 +75,9 @@ namespace Slingshot.CCB.Utilities
         // Set CcbApi.DumpResponseToXmlFile to true to save all API Responses to XML files and include them in the slingshot package
         public static bool DumpResponseToXmlFile { get; set; }
 
+        // Set ConsolidateScheduleNames to true to consolidate schedules names as 'Sunday at 11:00 AM'
+        public static bool ConsolidateScheduleNames { get; set; }
+
         /// <summary>
         /// Gets or sets the last run date.
         /// </summary>
@@ -874,9 +877,9 @@ namespace Slingshot.CCB.Utilities
                     scheduleId = Math.Abs( BitConverter.ToInt32( hashed, 0 ) ); // used abs to ensure positive number
                 }
 
-                foreach ( var location in eventDetails.Where( e => e.ScheduleName == specificSchedule ) )
+                foreach ( var schedule in eventDetails.Where( e => e.ScheduleName == specificSchedule ) )
                 {
-                    location.ScheduleId = scheduleId;
+                    schedule.ScheduleId = scheduleId;
                 }
             }
 
@@ -1018,7 +1021,13 @@ namespace Slingshot.CCB.Utilities
 
                             eventDetail.EventId = eventItem.Attribute( "id" ).Value.AsInteger();
                             eventDetail.GroupId = eventItem.Element( "group" ).Attribute( "id" ).Value.AsInteger();
-                            eventDetail.ScheduleName = eventItem.Element( "recurrence_description" ).Value;
+
+                            var scheduleName = eventItem.Element( "recurrence_description" ).Value;
+                            if ( CcbApi.ConsolidateScheduleNames )
+                            {
+                                scheduleName = $"{eventItem.Element( "start_datetime" ).Value.AsDateTime()?.DayOfWeek.ToString()} at {eventItem.Element( "start_time" ).Value}";
+                            }
+                            eventDetail.ScheduleName = scheduleName;
 
                             if ( eventItem.Element( "location" ) != null && eventItem.Element( "location" ).HasElements )
                             {

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbAttendance.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbAttendance.cs
@@ -12,7 +12,7 @@ namespace Slingshot.CCB.Utilities.Translators
 {
     public static class CcbAttendance
     {
-        public static List<Attendance> Translate(XElement inputAttendance, List<EventDetail> eventDetails )
+        public static List<Attendance> Translate( XElement inputAttendance, List<EventDetail> eventDetails )
         {
             List<Attendance> attendanceList = new List<Attendance>();
 

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbFinancialBatch.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbFinancialBatch.cs
@@ -11,7 +11,7 @@ namespace Slingshot.CCB.Utilities.Translators
 {
     public static class CcbFinancialBatch
     {
-        public static FinancialBatch Translate(XElement inputBatch )
+        public static FinancialBatch Translate( XElement inputBatch )
         {
             var financialBatch = new FinancialBatch();
             financialBatch.Id = inputBatch.Attribute( "id" ).Value.AsInteger();
@@ -29,10 +29,9 @@ namespace Slingshot.CCB.Utilities.Translators
                     financialBatch.Status = BatchStatus.Open;
                     break;
             }
-            
+
             financialBatch.CreatedDateTime = inputBatch.Element( "created" )?.Value.AsDateTime();
             financialBatch.ModifiedDateTime = inputBatch.Element( "modified" )?.Value.AsDateTime();
-
             financialBatch.CreatedByPersonId = inputBatch.Element( "creator" )?.Attribute( "id" )?.Value.AsIntegerOrNull();
             financialBatch.ModifiedByPersonId = inputBatch.Element( "modifier" )?.Attribute( "id" )?.Value.AsIntegerOrNull();
 

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbFinancialTransaction.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbFinancialTransaction.cs
@@ -11,7 +11,7 @@ namespace Slingshot.CCB.Utilities.Translators
 {
     public static class CcbFinancialTransaction
     {
-        public static FinancialTransaction Translate(XElement inputTransaction, int batchId)
+        public static FinancialTransaction Translate( XElement inputTransaction, int batchId )
         {
             var financialTransaction = new FinancialTransaction();
 
@@ -20,10 +20,10 @@ namespace Slingshot.CCB.Utilities.Translators
             financialTransaction.Summary = inputTransaction.Element( "grouping" )?.Value;
             financialTransaction.TransactionCode = inputTransaction.Element( "check_number" )?.Value;
             financialTransaction.TransactionDate = inputTransaction.Element( "date" )?.Value.AsDateTime();
-            financialTransaction.AuthorizedPersonId = inputTransaction.Element( "individual" )?.Attribute("id")?.Value.AsIntegerOrNull();
+            financialTransaction.AuthorizedPersonId = inputTransaction.Element( "individual" )?.Attribute( "id" )?.Value.AsIntegerOrNull();
 
             var source = inputTransaction.Element( "payment_type" )?.Value;
-            switch( source )
+            switch ( source )
             {
                 case "Online":
                     financialTransaction.TransactionSource = TransactionSource.Website;

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbFinancialTransaction.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbFinancialTransaction.cs
@@ -22,20 +22,24 @@ namespace Slingshot.CCB.Utilities.Translators
             financialTransaction.TransactionDate = inputTransaction.Element( "date" )?.Value.AsDateTime();
             financialTransaction.AuthorizedPersonId = inputTransaction.Element( "individual" )?.Attribute("id")?.Value.AsIntegerOrNull();
 
-            // note the api doesn't tell us the currency type
-            financialTransaction.CurrencyType = CurrencyType.Unknown;
-
             var source = inputTransaction.Element( "payment_type" )?.Value;
             switch( source )
             {
                 case "Online":
                     financialTransaction.TransactionSource = TransactionSource.Website;
+                    financialTransaction.CurrencyType = CurrencyType.CreditCard;
                     break;
                 case "Cash":
                     financialTransaction.TransactionSource = TransactionSource.OnsiteCollection;
+                    financialTransaction.CurrencyType = CurrencyType.Cash;
+                    break;
+                case "Check":
+                    financialTransaction.TransactionSource = TransactionSource.OnsiteCollection;
+                    financialTransaction.CurrencyType = CurrencyType.Check;
                     break;
                 default:
                     financialTransaction.TransactionSource = TransactionSource.OnsiteCollection; // best default?
+                    financialTransaction.CurrencyType = CurrencyType.Unknown;
                     break;
             }
 

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbFinancialTransactionDetail.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbFinancialTransactionDetail.cs
@@ -11,7 +11,7 @@ namespace Slingshot.CCB.Utilities.Translators
 {
     public static class CcbFinancialTransactionDetail
     {
-        public static FinancialTransactionDetail Translate(XElement inputTransactionDetail, int transactionId)
+        public static FinancialTransactionDetail Translate( XElement inputTransactionDetail, int transactionId )
         {
             var financialTransactionDetail = new FinancialTransactionDetail();
 
@@ -24,7 +24,7 @@ namespace Slingshot.CCB.Utilities.Translators
             financialTransactionDetail.CreatedDateTime = inputTransactionDetail.Element( "created" )?.Value.AsDateTime();
             financialTransactionDetail.ModifiedDateTime = inputTransactionDetail.Element( "modified" )?.Value.AsDateTime();
 
-            financialTransactionDetail.CreatedByPersonId = inputTransactionDetail.Element( "creator" )?.Attribute("id")?.Value.AsIntegerOrNull();
+            financialTransactionDetail.CreatedByPersonId = inputTransactionDetail.Element( "creator" )?.Attribute( "id" )?.Value.AsIntegerOrNull();
             financialTransactionDetail.ModifiedByPersonId = inputTransactionDetail.Element( "modifier" )?.Attribute( "id" )?.Value.AsIntegerOrNull();
 
             return financialTransactionDetail;

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbGroup.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbGroup.cs
@@ -22,7 +22,7 @@ namespace Slingshot.CCB.Utilities.Translators
 
             group.Id = inputGroup.Attribute( "id" ).Value.AsInteger();
             group.Name = inputGroup.Element( "name" )?.Value;
-            group.Description = inputGroup.Element( "description" )?.Value;
+            group.Description = inputGroup.Element( "description" )?.Value.RemoveCrLf();
             group.GroupTypeId = inputGroup.Element( "group_type" ).Attribute( "id" ).Value.AsInteger();
             group.CampusId = inputGroup.Element( "campus" ).Attribute( "id" ).Value.AsIntegerOrNull();
             group.Capacity = inputGroup.Element( "group_capacity" ).Value.AsIntegerOrNull();
@@ -105,7 +105,7 @@ namespace Slingshot.CCB.Utilities.Translators
                 {
                     var importAddress = new GroupAddress();
                     importAddress.GroupId = group.Id;
-                    importAddress.Street1 = address.Element( "street_address" ).Value;
+                    importAddress.Street1 = address.Element( "street_address" ).Value.RemoveCrLf();
                     importAddress.City = address.Element( "city" ).Value;
                     importAddress.State = address.Element( "state" ).Value;
                     importAddress.PostalCode = address.Element( "zip" ).Value;

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
@@ -226,7 +226,8 @@ namespace Slingshot.CCB.Utilities.Translators
                 if ( imageURI.IsNotNullOrWhitespace() && !imageURI.Contains( "profile-default.gif" ) )
                 {
                     // CCB encoded key expires too quickly, so download immediately instead of setting person.PersonPhotoUrl
-                    Task.Run( () => {
+                    Task.Run( () =>
+                    {
                         // save image locally
                         var imageResponse = WebRequest.Create( imageURI ).GetResponse();
                         var imageStream = imageResponse.GetResponseStream();

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
@@ -99,7 +99,7 @@ namespace Slingshot.CCB.Utilities.Translators
                     {
                         var importAddress = new PersonAddress();
                         importAddress.PersonId = person.Id;
-                        importAddress.Street1 = address.Element( "street_address" ).Value;
+                        importAddress.Street1 = address.Element( "street_address" ).Value.RemoveCrLf();
                         importAddress.City = address.Element( "city" ).Value;
                         importAddress.State = address.Element( "state" ).Value;
                         importAddress.PostalCode = address.Element( "zip" ).Value;

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
@@ -300,18 +300,18 @@ namespace Slingshot.CCB.Utilities.Translators
                 }
 
                 // dropdown fields
-                /*foreach ( var dropdownAttribute in inputPerson.Element( "user_defined_pulldown_fields" )?.Elements( "user_defined_pulldown_fields" ) )
+                foreach ( var dropdownAttribute in inputPerson.Element( "user_defined_pulldown_fields" )?.Elements( "user_defined_pulldown_field" ) )
                 {
-                    if ( dropdownAttribute.Element( "label" ).Value.IsNotNullOrWhitespace() && dropdownAttribute.Element( "text" ).Value.IsNotNullOrWhitespace() ) // not certain this is the correct key as discovery church did not have any...
+                    if ( dropdownAttribute.Element( "label" ).Value.IsNotNullOrWhitespace() && dropdownAttribute.Element( "selection" ).Value.IsNotNullOrWhitespace() )
                     {
                         person.Attributes.Add( new PersonAttributeValue
                         {
                             AttributeKey = dropdownAttribute.Element( "name" ).Value,
-                            AttributeValue = dropdownAttribute.Element( "text" ).Value, // not certain this is the correct key as discovery church did not have any...
-                            PersonId = person.PersonId
+                            AttributeValue = dropdownAttribute.Element( "selection" ).Value,
+                            PersonId = person.Id
                         } );
                     }
-                }*/
+                }
 
                 // write out person notes
                 if ( notes.Count > 0 )

--- a/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
+++ b/Slingshot.CCB/Slingshot.CCB/Utilities/Translators/CcbPerson.cs
@@ -69,10 +69,9 @@ namespace Slingshot.CCB.Utilities.Translators
                                 phoneType = "Mobile";
                                 break;
 
-                            // no longer used in CCB as of 11/31/17
-                            //case "contact":
-                            //    phoneType = "Contact";
-                            //    break;
+                            case "contact":
+                                phoneType = "Contact";
+                                break;
 
                             case "work":
                                 phoneType = "Work";

--- a/Slingshot.Core/Slingshot.Core/Utilities/ExtensionMethods/StringExtensions.cs
+++ b/Slingshot.Core/Slingshot.Core/Utilities/ExtensionMethods/StringExtensions.cs
@@ -31,6 +31,16 @@ namespace Slingshot.Core
         #region String Extensions
 
         /// <summary>
+        /// Removes any carriage return and/or line feed characters.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <returns></returns>
+        public static string RemoveCrLf( this string str )
+        {
+            return str.Replace( Environment.NewLine, " " ).Replace( "\x0A", " " );
+        }
+
+        /// <summary>
         /// Removes special characters from the string so that only Alpha, Numeric, '.' and '_' remain;
         /// </summary>
         /// <param name="str">The identifier.</param>

--- a/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
+++ b/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
@@ -361,17 +361,6 @@ namespace Slingshot.Core.Utilities
                     }
                 }
 
-                if ( importModel is PersonAttributeValue )
-                {
-                    var personAttributeValue = new PersonAttributeValue();
-                    var csvPersonAttributeValueWriter = csvWriters[personAttributeValue.GetType().Name];
-
-                    if ( csvPersonAttributeValueWriter != null )
-                    {
-                        csvPersonAttributeValueWriter.WriteRecord( ( PersonAttributeValue ) importModel );
-                    }
-                }
-
                 // if financial model write out any related models
                 if ( importModel is FinancialBatch )
                 {

--- a/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
+++ b/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
@@ -114,6 +114,12 @@ namespace Slingshot.Core.Utilities
                         textWriters.Add( personAddress.GetType().Name, (TextWriter)File.CreateText( $@"{_packageDirectory}\{personAddress.GetFileName()}" ) );
                     }
 
+                    if ( importModel is PersonAttributeValue )
+                    {
+                        var personAttributeValue = new PersonAttributeValue();
+                        textWriters.Add( personAttributeValue.GetType().Name, ( TextWriter ) File.CreateText( $@"{_packageDirectory}\{personAttributeValue.GetFileName()}" ) );
+                    }
+
                     // if model is for financial batch create related writers
                     if ( importModel is FinancialBatch  )
                     {
@@ -201,6 +207,14 @@ namespace Slingshot.Core.Utilities
                         var newPersonAddressCsvWriter = new CsvWriter( textWriters[personAddress.GetType().Name] );
                         csvWriters.Add( personAddress.GetType().Name, newPersonAddressCsvWriter );
                         newPersonAddressCsvWriter.WriteHeader<PersonAddress>();
+                    }
+
+                    if ( importModel is PersonAttributeValue )
+                    {
+                        var personAttributeValue = new PersonAttributeValue();
+                        var newPersonAttributeValueCsvWriter = new CsvWriter( textWriters[personAttributeValue.GetType().Name] );
+                        csvWriters.Add( personAttributeValue.GetType().Name, newPersonAttributeValueCsvWriter );
+                        newPersonAttributeValueCsvWriter.WriteHeader<PersonAttributeValue>();
                     }
 
                     // if model is for financial batch create related writers
@@ -344,6 +358,17 @@ namespace Slingshot.Core.Utilities
                                 csvPersonAddressWriter.WriteRecord( address );
                             }
                         }
+                    }
+                }
+
+                if ( importModel is PersonAttributeValue )
+                {
+                    var personAttributeValue = new PersonAttributeValue();
+                    var csvPersonAttributeValueWriter = csvWriters[personAttributeValue.GetType().Name];
+
+                    if ( csvPersonAttributeValueWriter != null )
+                    {
+                        csvPersonAttributeValueWriter.WriteRecord( ( PersonAttributeValue ) importModel );
                     }
                 }
 

--- a/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
+++ b/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
@@ -428,13 +428,13 @@ namespace Slingshot.Core.Utilities
 
                     // group attributes
                     var groupAttributeValue = new GroupAttributeValue();
-                    var csvPersonAttributeValueWriter = csvWriters[groupAttributeValue.GetType().Name];
+                    var csvGroupAttributeValueWriter = csvWriters[groupAttributeValue.GetType().Name];
 
-                    if ( csvPersonAttributeValueWriter != null )
+                    if ( csvGroupAttributeValueWriter != null )
                     {
                         foreach ( var attribute in ( (Group)importModel ).Attributes )
                         {
-                            csvPersonAttributeValueWriter.WriteRecord( attribute );
+                            csvGroupAttributeValueWriter.WriteRecord( attribute );
                         }
                     }
 

--- a/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
+++ b/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
@@ -124,6 +124,10 @@ namespace Slingshot.Core.Utilities
                         // person addresses
                         var personAddress = new PersonAddress();
                         textWriters.Add( personAddress.GetType().Name, (TextWriter)File.CreateText( $@"{_packageDirectory}\{personAddress.GetFileName()}" ) );
+
+                        // person search key
+                        var personSearchKey = new PersonSearchKey();
+                        textWriters.Add( personSearchKey.GetType().Name, (TextWriter)File.CreateText( $@"{_packageDirectory}\{personSearchKey.GetFileName()}" ) );
                     }
 
                     if ( importModel is PersonAttributeValue )

--- a/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
+++ b/Slingshot.Core/Slingshot.Core/Utilities/ImportPackage.cs
@@ -26,6 +26,12 @@ namespace Slingshot.Core.Utilities
 
         private static List<FamilyAddress> _familyAddresses = new List<FamilyAddress>();
 
+        /// <summary>
+        /// Gets the package directory.
+        /// </summary>
+        /// <value>
+        /// The package directory.
+        /// </value>
         public static string PackageDirectory
         {
             get


### PR DESCRIPTION
**Core and CCB**
* Added RemoveCrLf string extension to core and used to cleanup various multi-line XML responses.

**CCB**
* Applied auto-formatting to CCB code files.
* Removed default API username.
* Fixed Dump Response to Xml evaluation.
* Added feature to disable the Create Download Package button while running.
* Added currency type to transactions.
* Added test to de-duplicate Person Addresses (Family Id, Street Address, and Left 5 Postal Code)
* Added custom drop-down CCB person attributes as text Rock person attributes.
* Added significant events as date Rock person attributes.
* Added Contact number back to phone list.
* Added checkbox option to consolidate schedules (i.e. a single `Sunday at 11:00 AM` schedule will be created for all events on a Sunday at 11 am).
* Added input for user to set number of API loops.
* Added option to leave Modified Since date blank.
* Added input for user to set the page size of the Group request.

#### UI Enhancements
_Groups unchecked for privacy_  
![image](https://user-images.githubusercontent.com/3513589/61637889-54bfac00-ac66-11e9-94dd-e04089d753ce.png)
