### PR TITLE
F1 Export Improvements

### DIFF
--- a/Slingshot.F1/Slingshot.F1/Utilities/Translators/MDB/F1FinancialTransaction.cs
+++ b/Slingshot.F1/Slingshot.F1/Utilities/Translators/MDB/F1FinancialTransaction.cs
@@ -71,6 +71,19 @@ namespace Slingshot.F1.Utilities.Translators.MDB
                     break;
             }
 
+            switch ( row.Field<string>( "Fund_Type" ) )
+            {
+                case "Receipt":
+                    transaction.TransactionType = TransactionType.Receipt;
+                    break;
+                case "EventRegistration":
+                    transaction.TransactionType = TransactionType.EventRegistration;
+                    break;
+                default:
+                    transaction.TransactionType = TransactionType.Contribution;
+                    break;
+            }
+
             var accountId = 0;
             MD5 md5Hasher = MD5.Create();
             byte[] hashed;

--- a/Slingshot.F1/Slingshot.F1/Utilities/Translators/MDB/F1Group.cs
+++ b/Slingshot.F1/Slingshot.F1/Utilities/Translators/MDB/F1Group.cs
@@ -42,7 +42,10 @@ namespace Slingshot.F1.Utilities.Translators.MDB
             group.Name = row.Field<string>( "Group_Name" ).Left( 50 );
             group.GroupTypeId = row.Field<int>( "Group_Type_ID" );
             group.IsActive = row.Field<int>( "is_active" ) != 0;
-            group.IsPublic = row.Field<int>( "is_public" ) != 0;
+            if( row.Field<int?>( "is_public" ).HasValue )
+            {
+                group.IsPublic = row.Field<int?>( "is_public" ).Value != 0;
+            }
             group.MeetingDay = row.Field<string>( "ScheduleDay" );
             group.ParentGroupId = row.Field<int?>( "ParentGroupId" ) ?? 90000000 + group.GroupTypeId;
             group.Description = row.Field<string>( "Description" );

--- a/Slingshot.F1/Slingshot.F1/Utilities/Translators/MDB/F1Person.cs
+++ b/Slingshot.F1/Slingshot.F1/Utilities/Translators/MDB/F1Person.cs
@@ -34,25 +34,26 @@ namespace Slingshot.F1.Utilities.Translators.MDB
                 }
 
                 // names
-                string firstName = row.Field<string>( "first_name" );
+                // Limit the Name fields to 50 characters because the Rock DB has a limit of 50 characters.
+                string firstName = row.Field<string>( "first_name" ).Left(50);
                 if ( firstName.IsNotNullOrWhitespace() )
                 {
                     person.FirstName = firstName;
                 }
 
-                string nickName = row.Field<string>( "goes_by" );
+                string nickName = row.Field<string>( "goes_by" ).Left( 50 );
                 if ( nickName.IsNotNullOrWhitespace() )
                 {
                     person.NickName = nickName;
                 }
 
-                string middleName = row.Field<string>( "middle_name" );
+                string middleName = row.Field<string>( "middle_name" ).Left( 50 );
                 if ( middleName.IsNotNullOrWhitespace() )
                 {
                     person.MiddleName = middleName;
                 }
 
-                string lastName = row.Field<string>( "last_name" );
+                string lastName = row.Field<string>( "last_name" ).Left( 50 );
                 if ( lastName.IsNotNullOrWhitespace() )
                 {
                     person.LastName = lastName;
@@ -73,6 +74,10 @@ namespace Slingshot.F1.Utilities.Translators.MDB
                 string email = null;
                 // email
                 var emailrow = Communications.Select( "individual_id = " +  person.Id + " AND communication_type = 'Email'" ).FirstOrDefault();
+                if( emailrow == null )
+                {
+                    emailrow = Communications.Select( "individual_id = " + person.Id + " AND communication_type = 'Infellowship Login'" ).FirstOrDefault();
+                }
                 if( emailrow != null )
                 {
                     email = emailrow.Field<string>( "communication_value" );
@@ -292,7 +297,7 @@ namespace Slingshot.F1.Utilities.Translators.MDB
                 {
                     person.Attributes.Add( new PersonAttributeValue
                     {
-                        AttributeKey = "School",
+                        AttributeKey = "F1School",
                         AttributeValue = school,
                         PersonId = person.Id
                     } );
@@ -322,17 +327,30 @@ namespace Slingshot.F1.Utilities.Translators.MDB
                     } );
                 }
 
-                // former Church
-                string barcode = row.Field<string>( "Bar_Code" );
-                if ( barcode.IsNotNullOrWhitespace() )
+                // Default Tag Comment
+                string defaultTagComment = row.Field<string>( "Defatul_Tag_Commment" );
+                if ( defaultTagComment.IsNotNullOrWhitespace() )
                 {
                     person.Attributes.Add( new PersonAttributeValue
                     {
-                        AttributeKey = "BarCode",
-                        AttributeValue = barcode,
+                        AttributeKey = "F1_Default_Tag_Comment",
+                        AttributeValue = defaultTagComment,
                         PersonId = person.Id
                     } );
                 }
+
+                // Add Bar Code as Person Search Key
+                string barcode = row.Field<string>( "Bar_Code" );
+                if ( barcode.IsNotNullOrWhitespace() )
+                {
+                    person.PersonSearchKeys.Add( new PersonSearchKey
+                    {
+                        PersonId = person.Id,
+                        SearchValue = barcode
+                    } );
+                }
+
+
 
                 // Communications That aren't phone or email
                 var communicationAttributeValues = dtCommunicationValues.Select( "individual_id = " + person.Id );

--- a/Slingshot.F1/Slingshot.F1/Utilities/Translators/MDB/F1PersonPhone.cs
+++ b/Slingshot.F1/Slingshot.F1/Utilities/Translators/MDB/F1PersonPhone.cs
@@ -25,6 +25,19 @@ namespace Slingshot.F1.Utilities.Translators.MDB
                     phone.PersonId = row.Field<int>( "individual_id" );
                     phone.PhoneType = phoneType;
                     phone.PhoneNumber = phoneNumber.Left( 20 );
+                    phone.IsMessagingEnabled = false;
+                    if( row.Field<int>("listed") == 255)
+                    {
+                        phone.IsUnlisted = false;
+                        if( phoneType == "Mobile" || phoneType == "Cell" )
+                        {
+                            phone.IsMessagingEnabled = true;
+                        }
+                    }
+                    else
+                    {
+                        phone.IsUnlisted = true;
+                    }
                     return phone;
                 }
             }


### PR DESCRIPTION
Updated the SQL for Communications to get the most recent communication value per person per type.  It also joins back on the household table to set the indiviual_Id when it's only a household communication.

Fixed the SQL for getting Groups to include Groups that aren't included in the Group Description Table

Added the Default Tag Comment as an exported Attribute

Modified School Key to be F1 School.  This make a new attribugte in Rock vs using the Rock Attribute.

Moved the Barcode to a PersonSearch Key vs an Attribute

Added Logic for creating Transcations with the type "Recepit"

Fixed a bug for when "is_Public" column is null in setting if a group is public or not.

Trimed the length of all person names to 50 characters

Add logic so that if a person doesn't have an 'Email' communication type, to see if they have an Infellowship Login.  If so, use that as email.

Added exporting the IsUnlisted property of a phone number.

Added logic to set Mobile or Cell phone number types to SMS enabled if they're listed.