### PR TITLE
Iterate through paginated API when exporting

### DIFF
--- a/Slingshot.ElexioCommunity/Slingshot.ElexioCommunity/Utilities/ElexioCommunityApi.cs
+++ b/Slingshot.ElexioCommunity/Slingshot.ElexioCommunity/Utilities/ElexioCommunityApi.cs
@@ -231,7 +231,7 @@ namespace Slingshot.ElexioCommunity.Utilities
 
                     dynamic data = JsonConvert.DeserializeObject( response.Content );
 
-                    itemCount = data.itemCount ?? 0;
+                    itemCount = data.totalCount ?? 0;
                     var records = data.data;
 
                     if ( records != null )


### PR DESCRIPTION
Currently, this tool makes 1 request to the API and by default it seems it does an offset of 0 and limit of 1000 which may not bring back all the results needed.

This change will iterate through the pages via the API to get all the results as needed before continuing.

This was tested on live data with around 24k records to pull.